### PR TITLE
Blob response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ bin/
 obj/
 
 **/*.nupkg
+node_modules
+coverage

--- a/Scripts/ajax-wrapper.js
+++ b/Scripts/ajax-wrapper.js
@@ -130,6 +130,13 @@ options: {
                 delayLoading:
           }
 */
+    /**
+     * Perform an ajax request.
+     *
+     * @param {string} url Url to call
+     * @param {{ method: string, responseType: string }} options Options object
+     * @returns Ajax result.
+     */
     ajax: function (url, options) {
         var method = options.method || "GET";
         var async = options.async || true;
@@ -171,9 +178,18 @@ options: {
                 withCredentials: true,
             };
         }
+
+        if (options.responseType) {
+            ajaxOptions.xhr = function () {
+                var xhr = new XMLHttpRequest();
+                xhr.responseType = options.responseType;
+                return xhr;
+            };
+        }
+        
         var ajaxRequest = $.ajax(ajaxOptions)
-            .done(function (responseData) {
-                if (onDone) onDone(responseData);
+            .done(function (responseData, status, request) {
+                if (onDone) onDone(responseData, status, request);
             })
             .fail(function (xhr, textStatus, errorThrown) {
                 if (onFail) {

--- a/ajax-wrapper.nuspec
+++ b/ajax-wrapper.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Ajax-Wrapper.js</id>
     <title>Ajax Wrapper</title>
-    <version>9.1.1</version>
+    <version>9.2.0</version>
     <authors>nolanofra</authors>
     <owners>Università Bocconi</owners>
     <projectUrl>https://github.com/universitabocconi/ajax-wrapper.git</projectUrl>


### PR DESCRIPTION
Aggiunge la possibilità di ricevere come risposta di una chiamata ajax un blob.

Viene usato per scaricare le registrazioni in formato docx da Cabolo. Altrimenti il file scaricato risultava corrotto e non mi permetteva di leggerlo con Word.